### PR TITLE
Fixed bug with Map serialization, added alias for value of Configuration annotation

### DIFF
--- a/api/src/main/java/com/github/secretx33/sccfg/api/annotation/Configuration.java
+++ b/api/src/main/java/com/github/secretx33/sccfg/api/annotation/Configuration.java
@@ -38,9 +38,14 @@ public @interface Configuration {
      * on the relative path for that application (for Bukkit, it'll be inside plugin's data folder, and
      * for standalone applications it'll be relative to folder where the software is running on).
      * You can also explicitly provide extensions on the name, if you want, so, for example, {@code myfile.yml}
-     * is a valid name for a configuration of type {@link com.github.secretx33.sccfg.api.FileType#YAML}
+     * is a valid name for a configuration of type {@link com.github.secretx33.sccfg.api.FileType#YAML}.
      */
     String value() default "";
+
+    /**
+     * Alias for {@link Configuration#value()}.
+     */
+    String name() default "";
 
     /**
      * Specifies what file type that config should be.

--- a/bukkit-kotlin/src/main/kotlin/com/github/secretx33/sccfg/ConfigExtensions.kt
+++ b/bukkit-kotlin/src/main/kotlin/com/github/secretx33/sccfg/ConfigExtensions.kt
@@ -28,7 +28,7 @@ import kotlin.reflect.KClass
 
 
 /**
- * Extension for getting the singleton instance of config [T].
+ * Extension for getting the singleton instance of config [T]. This method is thread safe.
  *
  * **Hint:** if you want to instantiate the configuration class yourself, you can do that, just register
  * it whenever is convenient for you using [registerConfig] method.
@@ -40,7 +40,8 @@ import kotlin.reflect.KClass
 inline fun <reified T : Any> getConfig(): T = Config.getConfig(T::class.java)
 
 /**
- * Lazy extension for getting the singleton instance of config [T].
+ * Lazy extension for getting the singleton instance of config [T]. This method is thread safe and provides
+ * an instance of a thread safe `lazy`.
  *
  * **Hint:** if you want to instantiate the configuration class yourself, you can do that, just register
  * it whenever is convenient for you using [registerConfigs] method.
@@ -52,7 +53,9 @@ inline fun <reified T : Any> getConfig(): T = Config.getConfig(T::class.java)
 inline fun <reified T : Any> lazyConfig(): Lazy<T> = lazy { getConfig() }
 
 /**
- * Extension for registering your instance of a configuration class.
+ * Extension for registering your instance of a configuration class. This method is thread safe, as it
+ * guarantees that no overrides can happen when passing as argument instances of configs already registered,
+ * but the `ConfigOverrideException` thrown is only best-effort, so no guarantees can be made about it.
  *
  * @param config T the config instance
  * @return T the config instance

--- a/bukkit/src/main/java/com/github/secretx33/sccfg/Config.java
+++ b/bukkit/src/main/java/com/github/secretx33/sccfg/Config.java
@@ -61,7 +61,8 @@ public final class Config {
     private Config() {}
 
     /**
-     * Gets the instance of the {@code} configClass, instantiating it if it's not initiated yet.
+     * Gets the instance of the {@code} configClass, instantiating it if it's not initiated yet. This method is thread
+     * safe.
      *
      * @param configClass the config class
      * @param <T> the type of the config class
@@ -77,7 +78,9 @@ public final class Config {
     }
 
     /**
-     * Register an instance of a config class.
+     * Register an instance of a config class. This method is thread safe, as it guarantees that no overrides can
+     * happen when passing as argument instances of configs already registered - but the {@code ConfigOverrideException}
+     * thrown is only best-effort, so no guarantees can be made about it.
      *
      * @param configInstance the config instance
      * @param <T> the type of the config class
@@ -94,7 +97,9 @@ public final class Config {
     }
 
     /**
-     * Register multiple instances of config classes.
+     * Register multiple instances of config classes. This method is thread safe, as it guarantees that no overrides can
+     * happen when passing as argument instances of configs already registered - but the {@code ConfigOverrideException}
+     * thrown is only best-effort, so no guarantees can be made about it.
      *
      * @param configInstances the config instances
      * @throws MissingConfigAnnotationException if class of any instance inside {@code configInstances}

--- a/bukkit/src/main/java/com/github/secretx33/sccfg/Config.java
+++ b/bukkit/src/main/java/com/github/secretx33/sccfg/Config.java
@@ -61,8 +61,8 @@ public final class Config {
     private Config() {}
 
     /**
-     * Gets the instance of the {@code} configClass, instantiating it if it's not initiated yet. This method is thread
-     * safe.
+     * Gets the instance of the {@code} configClass, instantiating it if it's not initiated yet. This method
+     * is thread safe.
      *
      * @param configClass the config class
      * @param <T> the type of the config class
@@ -79,7 +79,7 @@ public final class Config {
 
     /**
      * Register an instance of a config class. This method is thread safe, as it guarantees that no overrides can
-     * happen when passing as argument instances of configs already registered - but the {@code ConfigOverrideException}
+     * happen when passing as argument instances of configs already registered, but the {@code ConfigOverrideException}
      * thrown is only best-effort, so no guarantees can be made about it.
      *
      * @param configInstance the config instance
@@ -97,8 +97,8 @@ public final class Config {
     }
 
     /**
-     * Register multiple instances of config classes. This method is thread safe, as it guarantees that no overrides can
-     * happen when passing as argument instances of configs already registered - but the {@code ConfigOverrideException}
+     * Register multiple instances of config classes. This method is thread safe, as it guarantees that no overrides
+     * can happen when passing as argument instances of configs already registered, but the {@code ConfigOverrideException}
      * thrown is only best-effort, so no guarantees can be made about it.
      *
      * @param configInstances the config instances

--- a/common/src/main/java/com/github/secretx33/sccfg/config/BaseConfigFactory.java
+++ b/common/src/main/java/com/github/secretx33/sccfg/config/BaseConfigFactory.java
@@ -239,8 +239,7 @@ public class BaseConfigFactory implements ConfigFactory {
         if (instances.containsKey(clazz)) {
             throw new ConfigOverrideException(clazz);
         }
-        final ConfigWrapper<?> wrapper = wrapInstance(instance);
-        instances.put(clazz, wrapper);
+        instances.computeIfAbsent(clazz, c -> wrapInstance(instance));
     }
 
     @Override

--- a/common/src/main/java/com/github/secretx33/sccfg/config/BaseConfigFactory.java
+++ b/common/src/main/java/com/github/secretx33/sccfg/config/BaseConfigFactory.java
@@ -176,7 +176,8 @@ public class BaseConfigFactory implements ConfigFactory {
     }
 
     private String parseConfigPath(final Class<?> clazz, final Configuration configuration) {
-        final String value = configuration.value().trim();
+        String value = configuration.value().trim();
+        if (value.isEmpty()) value = configuration.name().trim();
         final String lowerCasedValue = value.toLowerCase(Locale.US);
         final String extension = configuration.type().getExtension();
         if (value.isEmpty()) {


### PR DESCRIPTION
## Changes

- Added `name` as alias for `value` property of `@Configuration`.
- Added note about thread safeness of `getConfig`, `registerConfig`, and `registerConfigs` methods to make clear what kind of thread safeness they offer.

## Bug Fixes

- The values from the config class instance were being replaced by the serializable equivalent of their values, so a `Map<String, ItemStack[]>` would get replaced by a `Map<String, List<String>>` or something like that, which caused the `AbstractSerializer#setValueOnField` method to throw IllegalArgumentException.  `Map<String, ItemStack[]>` is one of the types which triggered that issue.